### PR TITLE
Removed libgcc-ng and libstdcxx-ng pins as they are no longer needed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,30 +18,16 @@ requirements:
     - python {{ python }}
     - cmake {{ cmake }}
     - ninja {{ ninja }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
-  host: 
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
 
 outputs:
   - name: gtest
     version: {{ version }}
     requirements:
-      host:
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
       build:
         - {{ compiler('cxx') }}
         - python {{ python }}
         - cmake {{ cmake }}
         - ninja {{ ninja }}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}  
       run_constrained:
         - gmock {{ version }}
     files:
@@ -66,13 +52,7 @@ outputs:
         - python {{ python }}
         - cmake {{ cmake }}
         - ninja {{ ninja }}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
       host:
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
         - {{ pin_subpackage('gtest', exact=True) }}
       run:
         - {{ pin_subpackage('gtest', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,16 +18,30 @@ requirements:
     - python {{ python }}
     - cmake {{ cmake }}
     - ninja {{ ninja }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                                   # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                             # [x86_64 and c_compiler_version == "7.2.*"]
+  host:
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                                   # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                             # [x86_64 and c_compiler_version == "7.2.*"]
 
 outputs:
   - name: gtest
     version: {{ version }}
     requirements:
+      host:
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                               # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                         # [x86_64 and c_compiler_version == "7.2.*"]
       build:
         - {{ compiler('cxx') }}
         - python {{ python }}
         - cmake {{ cmake }}
         - ninja {{ ninja }}
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                               # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                         # [x86_64 and c_compiler_version == "7.2.*"]
       run_constrained:
         - gmock {{ version }}
     files:
@@ -52,7 +66,13 @@ outputs:
         - python {{ python }}
         - cmake {{ cmake }}
         - ninja {{ ninja }}
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                               # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                         # [x86_64 and c_compiler_version == "7.2.*"]
       host:
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                               # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                         # [x86_64 and c_compiler_version == "7.2.*"]
         - {{ pin_subpackage('gtest', exact=True) }}
       run:
         - {{ pin_subpackage('gtest', exact=True) }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed pins for libgcc-ng and libstdcxx-ng as they are no longer needed.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
