### PR TITLE
Revert "Update to v1.17.0 to fix abseil-cpp failure"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.17.0" %}
+{% set version = "1.13.0" %}
 
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/google/googletest/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
+  sha256: ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363
 
 build:
   number: 1


### PR DESCRIPTION
Reverts open-ce/gtest-feedstock#9